### PR TITLE
Add github releases pypi auto upload action

### DIFF
--- a/.github/workflows/ci-pypi-deploy.yml
+++ b/.github/workflows/ci-pypi-deploy.yml
@@ -1,0 +1,24 @@
+name: package-release
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+     - master
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: build and upload release to pypi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: casperdcl/deploy-pypi@v2
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          pip: wheel -w dist/ --no-deps .
+          upload: ${{ github.event_name == 'release' && github.event.action == 'published' }}


### PR DESCRIPTION
Hi @dbstein!

First, thank you for writing `fast_interp`! I've made a frequent use of it and find it very useful. We're currently using it in a project called [advtraj](https://github.com/ParaConUK/advtraj) and at the time I included the source-code directly into our tool because it wasn't working with python3 (and I found a small bug, but I think @ReadingClouds has been in touch with you about that). Because we would like to put `advtraj` on pypi, it would be really great if you would put `fast_interp` on pypi too.

To help with that this pull-request adds a Github Action which automatically builds and publishes any releases
tagged on github to pypi.org. All you need to do is add 1) add a pypi API key to a "repository secret" for this github repository called `PYPI_TOKEN`, 2) merge this pull-request and 3) create a release here on github.

Alternatively, if you I could do all this for you if you would trust me to be a collaborator on your repository :)

I use this way of publishing to pypi in many places, you can see an example here: https://github.com/convml/convml-data. It makes it really easy to put new changes on pypi.

You can get a pypi upload token at https://pypi.org/manage/account/token/ and here are instructions on adding this to your repo's secrets: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository